### PR TITLE
`dls_root` should be deleted before terminal GC.

### DIFF
--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -82,9 +82,6 @@ DOMAIN_STATE(uintnat, requested_major_slice)
 
 DOMAIN_STATE(uintnat, requested_minor_gc)
 
-DOMAIN_STATE(caml_root, read_fault_ret_val)
-/* Global root for return value of a read fault */
-
 DOMAIN_STATE(intnat, critical_section_nesting)
 
 DOMAIN_STATE(struct interrupt*, pending_interrupts)

--- a/testsuite/tests/parallel/domain_dls.ml
+++ b/testsuite/tests/parallel/domain_dls.ml
@@ -13,7 +13,8 @@ let check () =
   let v1 = Option.get (Domain.DLS.get k1) in
   let v2 = Option.get (Domain.DLS.get k2) in
   assert (v1 = 100);
-  assert (v2 = 200.0)
+  assert (v2 = 200.0);
+  Gc.major ()
 
 let _ =
   let domains = Array.init 3 (fun _ -> Domain.spawn(check)) in


### PR DESCRIPTION
Deleting the global root pushes an object into the mark stack. Hence,
before tearing down the GC, a final GC needs to be performed. The fix is
to move the root deletion before the terminal GC.