### PR TITLE
testsuite: add tests for backtrace_last_exn and systhreads

### DIFF
--- a/testsuite/tests/backtrace/backtrace_systhreads.ml
+++ b/testsuite/tests/backtrace/backtrace_systhreads.ml
@@ -1,0 +1,43 @@
+(* TEST
+
+flags = "-g"
+ocamlrunparam += ",b=1"
+
+* hassysthreads
+include systhreads
+** bytecode
+** native
+
+*)
+
+let throw_exn msg = failwith msg [@@inline never]
+
+let thread_func delay =
+  Thread.yield ();
+  try throw_exn (string_of_int delay) with
+  | exn ->
+     Thread.delay (float_of_int delay);
+     Gc.minor ();
+     raise exn
+
+let thread_backtrace (cond, mut) =
+  Thread.yield ();
+  try throw_exn "backtrace" with
+  | exn ->
+     Mutex.lock mut;
+     Condition.wait cond mut;
+     raise exn
+
+let () =
+  Random.self_init ();
+  let mut = Mutex.create () in
+  let cond = Condition.create () in
+  let backtrace_thread = Thread.create thread_backtrace (cond, mut) in
+  let threads =
+    List.init 4 begin fun i ->
+      Thread.create thread_func i
+      end
+  in
+  List.iter Thread.join threads;
+  Condition.signal cond;
+  Thread.join backtrace_thread

--- a/testsuite/tests/backtrace/backtrace_systhreads.reference
+++ b/testsuite/tests/backtrace/backtrace_systhreads.reference
@@ -1,0 +1,25 @@
+Thread 2 killed on uncaught exception Failure("0")
+Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 17, characters 6-37
+Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 21, characters 5-14
+Called from Thread.create.(fun) in file "thread.ml", line 41, characters 8-14
+Thread 3 killed on uncaught exception Failure("1")
+Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 17, characters 6-37
+Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 21, characters 5-14
+Called from Thread.create.(fun) in file "thread.ml", line 41, characters 8-14
+Thread 4 killed on uncaught exception Failure("2")
+Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 17, characters 6-37
+Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 21, characters 5-14
+Called from Thread.create.(fun) in file "thread.ml", line 41, characters 8-14
+Thread 5 killed on uncaught exception Failure("3")
+Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 17, characters 6-37
+Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 21, characters 5-14
+Called from Thread.create.(fun) in file "thread.ml", line 41, characters 8-14
+Thread 1 killed on uncaught exception Failure("backtrace")
+Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+Called from Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 25, characters 6-27
+Re-raised at Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 29, characters 5-14
+Called from Thread.create.(fun) in file "thread.ml", line 41, characters 8-14


### PR DESCRIPTION
This adds a test to this branch to check that `backtrace_last_exn` is behaving normally with systhreads.
It is a bit heavy handed, maybe sleeping a bit too much, but I think the logic is sound enough.
The output seems good (the Re-raise are fine in the bracktrace).